### PR TITLE
Add cylinder mesh for (rigid) Cylinder problem

### DIFF
--- a/src/oasismove/problems/NSCoupled/Cylinder.py
+++ b/src/oasismove/problems/NSCoupled/Cylinder.py
@@ -5,8 +5,8 @@ __date__ = "2014-04-04"
 __copyright__ = "Copyright (C) 2014 " + __author__
 __license__ = "GNU Lesser GPL version 3 or any later version"
 
-from ..Cylinder import *
-from ..NSCoupled import *
+from oasismove.problems.NSCoupled import *
+from oasismove.problems.Cylinder import *
 
 
 # Override some problem specific parameters
@@ -15,13 +15,24 @@ def problem_parameters(NS_parameters, scalar_components, **NS_namespace):
         omega=1.0,
         max_iter=100,
         plot_interval=10,
-        velocity_degree=2)
+        velocity_degree=2,
+        mesh_path="src/oasismove/mesh/cylinder.xml",
+    )
 
     scalar_components += ["c", "d"]
 
 
 def scalar_source(c_, d_, **NS_namespace):
     return {"c": -Constant(0.1) * c_ * c_, "d": -Constant(0.25) * c_ * d_ * d_}
+
+
+def mesh(mesh_path, dt, **NS_namespace):
+    # Import mesh
+    print(mesh_path)
+    mesh = Mesh(mesh_path)
+
+    print_mesh_information(mesh, dt, dim=2)
+    return mesh
 
 
 def create_bcs(VQ, Um, CG, V, element, **NS_namespace):

--- a/src/oasismove/problems/NSfracStep/Cylinder.py
+++ b/src/oasismove/problems/NSfracStep/Cylinder.py
@@ -9,9 +9,8 @@ import pickle
 from os import getcwd
 
 import matplotlib.pyplot as plt
-
-from ..Cylinder import *
-from ..NSfracStep import *
+from oasismove.problems.NSfracStep import *
+from oasismove.problems.Cylinder import *
 
 
 def problem_parameters(commandline_kwargs, NS_parameters, scalar_components,
@@ -35,13 +34,24 @@ def problem_parameters(commandline_kwargs, NS_parameters, scalar_components,
             plot_interval=10,
             velocity_degree=2,
             print_intermediate_info=100,
-            use_krylov_solvers=True)
+            use_krylov_solvers=True,
+            mesh_path="src/oasismove/mesh/cylinder.xml",
+        )
         NS_parameters['krylov_solvers'].update(dict(monitor_convergence=True))
         NS_parameters['velocity_krylov_solver'].update(dict(preconditioner_type='jacobi',
                                                             solver_type='bicgstab'))
 
     scalar_components.append("alfa")
     Schmidt["alfa"] = 0.1
+
+
+def mesh(mesh_path, dt, **NS_namespace):
+    # Import mesh
+    print(mesh_path)
+    mesh = Mesh(mesh_path)
+
+    print_mesh_information(mesh, dt, dim=2)
+    return mesh
 
 
 def create_bcs(V, Q, Um, H, **NS_namespace):


### PR DESCRIPTION
* Add cylinder mesh for `Cylinder.py` problem
* Use `mesh_path` parameter for rigid Cylinder problem

Fixes #27 

Command to run (NSfracStep):
```
oasismove NSfracStep problem=Cylinder solver=IPCS_ABCN mesh_path=src/oasismove/mesh/cylinder.xml
```
or (NSCoupled):
```
oasismove NSCoupled problem=Cylinder mesh_path=src/oasismove/mesh/cylinder.xml
```

