### PR TITLE
Propagate paths

### DIFF
--- a/src/oasismove/NSfracStep.py
+++ b/src/oasismove/NSfracStep.py
@@ -48,7 +48,7 @@ if problemspec is None:
     problemspec = importlib.util.find_spec(problemname)
 if problemspec is None:
     raise RuntimeError(problemname + ' not found')
-
+mesh_path = commandline_kwargs.get('mesh_path', None)
 # Import the problem module
 print('Importing problem module ' + problemname + ':\n' + problemspec.origin)
 problemmod = importlib.util.module_from_spec(problemspec)
@@ -76,6 +76,7 @@ if restart_folder is not None:
     t = params["t"]
     tstep = params["tstep"]
     previous_velocity_degree = params["velocity_degree"]
+
 
 # Import chosen functionality from solvers
 solver = importlib.import_module('.'.join(('oasismove.solvers.NSfracStep', solver)))

--- a/src/oasismove/NSfracStep.py
+++ b/src/oasismove/NSfracStep.py
@@ -48,7 +48,7 @@ if problemspec is None:
     problemspec = importlib.util.find_spec(problemname)
 if problemspec is None:
     raise RuntimeError(problemname + ' not found')
-mesh_path = commandline_kwargs.get('mesh_path', None)
+
 # Import the problem module
 print('Importing problem module ' + problemname + ':\n' + problemspec.origin)
 problemmod = importlib.util.module_from_spec(problemspec)

--- a/src/oasismove/common/io.py
+++ b/src/oasismove/common/io.py
@@ -114,6 +114,7 @@ def save_tstep_solution_xdmf(tstep, q_, u_, newfolder, tstepfiles, output_timese
     if MPI.rank(MPI.comm_world) == 0:
         if not path.exists(path.join(timefolder, "params.dat")):
             f = open(path.join(timefolder, 'params.dat'), 'wb')
+            NS_parameters.pop("mesh")
             pickle.dump(NS_parameters, f)
 
 

--- a/src/oasismove/problems/NSCoupled/Cylinder.py
+++ b/src/oasismove/problems/NSCoupled/Cylinder.py
@@ -7,16 +7,18 @@ __license__ = "GNU Lesser GPL version 3 or any later version"
 
 from oasismove.problems.NSCoupled import *
 from oasismove.problems.Cylinder import *
-
+from pathlib import Path
 
 # Override some problem specific parameters
+
+
 def problem_parameters(NS_parameters, scalar_components, **NS_namespace):
     NS_parameters.update(
         omega=1.0,
         max_iter=100,
         plot_interval=10,
         velocity_degree=2,
-        mesh_path="src/oasismove/mesh/cylinder.xml",
+        mesh_path="src/oasismove/mesh/cylinder.xdmf",
     )
 
     scalar_components += ["c", "d"]
@@ -29,7 +31,12 @@ def scalar_source(c_, d_, **NS_namespace):
 def mesh(mesh_path, dt, **NS_namespace):
     # Import mesh
     print(mesh_path)
-    mesh = Mesh(mesh_path)
+    if Path(mesh_path).suffix == ".xml":
+        mesh = Mesh(mesh_path)
+    elif Path(mesh_path).suffix == ".xdmf":
+        mesh = Mesh()
+        with XDMFFile(mesh_path) as infile:
+            infile.read(mesh)
 
     print_mesh_information(mesh, dt, dim=2)
     return mesh

--- a/src/oasismove/problems/NSCoupled/Cylinder.py
+++ b/src/oasismove/problems/NSCoupled/Cylinder.py
@@ -5,8 +5,8 @@ __date__ = "2014-04-04"
 __copyright__ = "Copyright (C) 2014 " + __author__
 __license__ = "GNU Lesser GPL version 3 or any later version"
 
-from ..Cylinder import *
-from ..NSCoupled import *
+from oasismove.problems.NSCoupled import *
+from oasismove.problems.Cylinder import *
 
 
 # Override some problem specific parameters
@@ -15,13 +15,24 @@ def problem_parameters(NS_parameters, scalar_components, **NS_namespace):
         omega=1.0,
         max_iter=100,
         plot_interval=10,
-        velocity_degree=2)
+        velocity_degree=2,
+        mesh_path="src/oasismove/mesh/cylinder.xml",
+    )
 
     scalar_components += ["c", "d"]
 
 
 def scalar_source(c_, d_, **NS_namespace):
     return {"c": -Constant(0.1) * c_ * c_, "d": -Constant(0.25) * c_ * d_ * d_}
+
+
+def mesh(mesh_path, dt, **NS_namespace):
+    # Import mesh
+    print(mesh_path)
+    mesh = Mesh(mesh_path)
+
+    print_mesh_information(mesh, dt, dim=2)
+    return mesh
 
 
 def create_bcs(VQ, Um, CG, V, element, **NS_namespace):

--- a/src/oasismove/problems/NSfracStep/Cylinder.py
+++ b/src/oasismove/problems/NSfracStep/Cylinder.py
@@ -11,6 +11,7 @@ from os import getcwd
 import matplotlib.pyplot as plt
 from oasismove.problems.NSfracStep import *
 from oasismove.problems.Cylinder import *
+from pathlib import Path
 
 
 def problem_parameters(commandline_kwargs, NS_parameters, scalar_components,
@@ -23,7 +24,6 @@ def problem_parameters(commandline_kwargs, NS_parameters, scalar_components,
         NS_parameters.update(pickle.load(f))
         NS_parameters['restart_folder'] = restart_folder
         globals().update(NS_parameters)
-
     else:
         # Override some problem specific parameters
         NS_parameters.update(
@@ -35,7 +35,7 @@ def problem_parameters(commandline_kwargs, NS_parameters, scalar_components,
             velocity_degree=2,
             print_intermediate_info=100,
             use_krylov_solvers=True,
-            mesh_path="src/oasismove/mesh/cylinder.xml",
+            mesh_path=commandline_kwargs["mesh_path"],
         )
         NS_parameters['krylov_solvers'].update(dict(monitor_convergence=True))
         NS_parameters['velocity_krylov_solver'].update(dict(preconditioner_type='jacobi',
@@ -48,7 +48,12 @@ def problem_parameters(commandline_kwargs, NS_parameters, scalar_components,
 def mesh(mesh_path, dt, **NS_namespace):
     # Import mesh
     print(mesh_path)
-    mesh = Mesh(mesh_path)
+    if Path(mesh_path).suffix == ".xml":
+        mesh = Mesh(mesh_path)
+    elif Path(mesh_path).suffix == ".xdmf":
+        mesh = Mesh()
+        with XDMFFile(mesh_path) as infile:
+            infile.read(mesh)
 
     print_mesh_information(mesh, dt, dim=2)
     return mesh

--- a/src/oasismove/problems/NSfracStep/Cylinder.py
+++ b/src/oasismove/problems/NSfracStep/Cylinder.py
@@ -9,9 +9,8 @@ import pickle
 from os import getcwd
 
 import matplotlib.pyplot as plt
-
-from ..Cylinder import *
-from ..NSfracStep import *
+from oasismove.problems.NSfracStep import *
+from oasismove.problems.Cylinder import *
 
 
 def problem_parameters(commandline_kwargs, NS_parameters, scalar_components,
@@ -35,13 +34,24 @@ def problem_parameters(commandline_kwargs, NS_parameters, scalar_components,
             plot_interval=10,
             velocity_degree=2,
             print_intermediate_info=100,
-            use_krylov_solvers=True)
+            use_krylov_solvers=True,
+            mesh_path="src/oasismove/mesh/cylinder.xml",
+        )
         NS_parameters['krylov_solvers'].update(dict(monitor_convergence=True))
         NS_parameters['velocity_krylov_solver'].update(dict(preconditioner_type='jacobi',
                                                             solver_type='bicgstab'))
 
     scalar_components.append("alfa")
     Schmidt["alfa"] = 0.1
+
+
+def mesh(mesh_path, dt, **NS_namespace):
+    # Import mesh
+    print(mesh_path)
+    mesh = Mesh(mesh_path)
+
+    print_mesh_information(mesh, dt, dim=2)
+    return mesh
 
 
 def create_bcs(V, Q, Um, H, **NS_namespace):


### PR DESCRIPTION
Paths in other PR were not propagated. Fixed in this PR.

Note that the `xml` file only exists in `tests/cylinder.xml`.

Also add handling for XMDFFiles.

Note that it is unclear to me if the results are sensible (Looking at the checkpoint in paraview does not give a reasonable solution).